### PR TITLE
Fix local name of klayer provider in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A terraform provider to manage your klayers (https://github.com/keithrozario/Kla
 ```terraform
 terraform {
   required_providers {
-    klayer = {
+    klayers = {
       version = "~> 1.0.0"
       source  = "ldcorentin/klayer"
     }


### PR DESCRIPTION
Since the resources are prefixed with `klayers_`, the local name of the provider should be `klayers` (instead of `klayer`).

> If a resource doesn't specify which provider configuration to use, Terraform interprets the first word of the resource type as a local provider name.

See also https://developer.hashicorp.com/terraform/language/providers/requirements#local-names

---

With the currently documented way of adding the provider `ldcorentin/klayer` to the `required_providers`, you might get the following error when running `terraform init`:

```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/klayers: provider registry registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/klayers
```